### PR TITLE
Exibir o campo "Emitir nota fiscal quando" sempre  #84

### DIFF
--- a/modules/addons/gofasnfeio/functions.php
+++ b/modules/addons/gofasnfeio/functions.php
@@ -973,7 +973,7 @@ if (!function_exists('gnfe_save_client_issue_invoice_cond')) {
  */
 if (!function_exists('gnfe_insert_issue_nfe_cond_in_database')) {
     function gnfe_insert_issue_nfe_cond_in_database() {
-        $conditions = 'Seguir configuração do módulo NFE.io,Quando a fatura é gerada,Quando a fatura é paga,Manualmente';
+        $conditions = 'Seguir configuração do módulo NFE.io,Quando a fatura é gerada,Quando a fatura é paga';
 
         $previousConditions = Capsule::table('tbladdonmodules')
                             ->where('module', '=', 'gofasnfeio')

--- a/modules/addons/gofasnfeio/functions.php
+++ b/modules/addons/gofasnfeio/functions.php
@@ -973,7 +973,7 @@ if (!function_exists('gnfe_save_client_issue_invoice_cond')) {
  */
 if (!function_exists('gnfe_insert_issue_nfe_cond_in_database')) {
     function gnfe_insert_issue_nfe_cond_in_database() {
-        $conditions = 'Seguir configuração do módulo NFE.io,Quando a fatura é gerada,Quando a fatura é paga';
+        $conditions = 'Quando a fatura é gerada,Quando a fatura é paga,Seguir configuração do módulo NFE.io';
 
         $previousConditions = Capsule::table('tbladdonmodules')
                             ->where('module', '=', 'gofasnfeio')

--- a/modules/addons/gofasnfeio/functions.php
+++ b/modules/addons/gofasnfeio/functions.php
@@ -973,7 +973,7 @@ if (!function_exists('gnfe_save_client_issue_invoice_cond')) {
  */
 if (!function_exists('gnfe_insert_issue_nfe_cond_in_database')) {
     function gnfe_insert_issue_nfe_cond_in_database() {
-        $conditions = 'Quando a fatura é gerada,Quando a fatura é paga,Seguir configuração do módulo NFE.io';
+        $conditions = 'Seguir configuração do módulo NFE.io,Quando a fatura é gerada,Quando a fatura é paga,Manualmente';
 
         $previousConditions = Capsule::table('tbladdonmodules')
                             ->where('module', '=', 'gofasnfeio')

--- a/modules/addons/gofasnfeio/hooks/customclientissueinvoice.php
+++ b/modules/addons/gofasnfeio/hooks/customclientissueinvoice.php
@@ -1,16 +1,14 @@
 <?php
 
 use WHMCS\Database\Capsule;
-
-if (gnfe_config('issue_note_default_cond') !== 'Manualmente') {
-    gnfe_insert_issue_nfe_cond_in_database();
-
+  
     if (Capsule::schema()->hasTable('mod_nfeio_custom_configs')) {
         return ['Emitir nota fiscal quando' => gnfe_show_issue_invoice_conds($vars['userid'])];
     } else {
         gnfe_verifyInstall();
+        gnfe_insert_issue_nfe_cond_in_database();
         return [
             'Módulo NFE.io' => 'Atualize a página para exibir as informações.'
         ];
     }
-}
+


### PR DESCRIPTION
Alterado lógica para exibição do campo "Emitir nota fiscal quando" no perfil do cliente e também inserido a opção "Manualmente" na lista.

Agora independente da opção global, o dropdown é exibido no perfil.

![image](https://user-images.githubusercontent.com/5316107/133664711-1a34e85b-6cac-4b24-87d2-7edc664e5b16.png)

Testado em todas as condições possíveis e notas emitindo de acordo com as configurações selecionadas, tanto por cliente quanto globalmente.

Resolve a questão #84 