### PR TITLE
alterada lógica de verificação de registro em mod_nfeio_custom_configs

### DIFF
--- a/modules/addons/gofasnfeio/functions.php
+++ b/modules/addons/gofasnfeio/functions.php
@@ -949,22 +949,28 @@ if (!function_exists('gnfe_save_client_issue_invoice_cond')) {
      * @var $invoiceCond string
      */
     function gnfe_save_client_issue_invoice_cond($clientId, $newCond) {
-        $previousClientCond = Capsule::table('mod_nfeio_custom_configs')->where('client_id', '=', $clientId)->get(['value'])[0]->value;
+        
+        // pega o primeiro registro disponível em mod_nfeio_custom_configs para o ID do cliente
+        $clientCustomConfig = Capsule::table('mod_nfeio_custom_configs')->where('client_id', $clientId)->first();
 
-        if ($newCond !== $previousClientCond) {
-            if ($previousClientCond == null) {
-                Capsule::table('mod_nfeio_custom_configs')->insert([
-                    'key' => 'issue_nfe_cond',
-                    'client_id' => $clientId,
-                    'value' => $newCond
-                ]);
-            } else {
-                Capsule::table('mod_nfeio_custom_configs')
-                    ->where('client_id', '=', $clientId)
-                    ->where('key', '=', 'issue_nfe_cond')
-                    ->update(['value' => $newCond]);
-            }
+        // caso cliente já possua uma configuração personalizada, atualiza baseado no ID do registro já encontrado
+        // na tabela mod_nfeio_custom_configs
+        if ($clientCustomConfig) {
+
+            Capsule::table('mod_nfeio_custom_configs')
+                ->where('id', $clientCustomConfig->id)
+                ->update(['value' => $newCond]);
+
+        } else {
+            // senão insere um novo
+            Capsule::table('mod_nfeio_custom_configs')->insert([
+                'key' => 'issue_nfe_cond',
+                'client_id' => $clientId,
+                'value' => $newCond
+            ]);
+
         }
+
     }
 }
 

--- a/modules/addons/gofasnfeio/functions.php
+++ b/modules/addons/gofasnfeio/functions.php
@@ -916,7 +916,7 @@ if (!function_exists('gnfe_show_issue_invoice_conds')) {
         $conditions = Capsule::table('tbladdonmodules')->where('module', '=', 'gofasnfeio')->where('setting', '=', 'issue_note_conditions')->get(['value'])[0]->value;
         $conditions = explode(',', $conditions);
 
-        $previousClientCond = Capsule::table('mod_nfeio_custom_configs')->where('client_id', '=', $clientId)->get(['value'])[0]->value;
+        $previousClientCond = Capsule::table('mod_nfeio_custom_configs')->where('client_id', '=', $clientId)->first()->value;
 
         $select = '<select name="issue_note_cond" class="form-control select-inline">';
 
@@ -949,7 +949,7 @@ if (!function_exists('gnfe_save_client_issue_invoice_cond')) {
      * @var $invoiceCond string
      */
     function gnfe_save_client_issue_invoice_cond($clientId, $newCond) {
-        
+
         // pega o primeiro registro disponível em mod_nfeio_custom_configs para o ID do cliente
         $clientCustomConfig = Capsule::table('mod_nfeio_custom_configs')->where('client_id', $clientId)->first();
 


### PR DESCRIPTION
alterada lógica de verificação de registro já existente para cliente em mod_nfeio_custom_configs #85

Para evitar duplicidade de registros como estava ocorrendo, agora é feita uma verificação da existência de algum registro para o _client_id_ e retornando o primeiro. Caso exista algum registro é atualizado (com base na coluna _id_ da tabela mod_nfeio_custom_configs e não mais comparando _value_ com `null`), caso não exista nenhum é inserido um novo.

Por buscar apenas o primeiro (usando o método `first()`) mesmo que haja duplicidade de informações para o mesmo Id do cliente em mod_nfeio_custom_configs não será apresentado nenhum erro ou gerado qualquer duplicidade de registros (mas caso já existam duplicados eles permanecerão). Sempre será atualizado e consultado o primeiro que for encontrado.

Também foi garantido que no dropdown no perfil do cliente seja buscado o primeiro registro encontrado (também usando o método `first(()`).