### PR TITLE
fix: data inicial de seleção de notas em fila retornando nulo

### DIFF
--- a/modules/addons/NFEioServiceInvoices/lib/Hooks/AfterCronJob.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Hooks/AfterCronJob.php
@@ -40,13 +40,19 @@ class AfterCronJob
         $storage = new \WHMCSExpert\Addon\Storage($storageKey);
         $dataAtual = date('Y-m-d H:i:s');
         // caso não exista valor para initial_date inicia define data que garanta a execução da rotina
-        $initialDate =  empty($storage->get('initial_date')) ? $storage->get('initial_date') : '1970-01-01';
+        $initialDate =  (! empty($storage->get('initial_date'))) ? $storage->get('initial_date') : '1970-01-01 00:00:00';
 
         // atualiza a data da ultima cron
         $storage->set('last_cron', $dataAtual);
 
         $hasNfWaiting = Capsule::table($serviceInvoicesTable)->whereBetween('created_at', [$initialDate, $dataAtual])->where('status', '=', 'Waiting')->count();
-        logModuleCall('NFEioServiceInvoices', 'Hook - AfterCronJob', "{$hasNfWaiting} notas a serem geradas", $hasNfWaiting);
+        logModuleCall('NFEioServiceInvoices', 'Hook - AfterCronJob', "{$hasNfWaiting} notas a serem geradas", array(
+            [
+                'total de notas' => $hasNfWaiting,
+                'data atual' => $dataAtual,
+                'data inicial' => $initialDate,
+            ]
+        ));
 
         if ($hasNfWaiting) {
 

--- a/modules/addons/NFEioServiceInvoices/lib/Models/ModuleConfiguration/Repository.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Models/ModuleConfiguration/Repository.php
@@ -361,7 +361,7 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
         // define 'on' como padrão para discount_items
         $storage->set('discount_items', 'on');
         // inicia valor para a chave initial_date
-        $date = date('Y-m-d');
+        $date = date('Y-m-d H:i:s');
         $storage->set('initial_date', $date);
 
     }


### PR DESCRIPTION
Corrige problema de valor para initial_date retornando nulo, o que impede a seleção das notas que estão em fila para emissão ocorrer como esperado.

refs: #139