### PR TITLE
[BUG] Nota Fiscal com status "processando" quando emissão falha #143

### DIFF
--- a/modules/addons/NFEioServiceInvoices/lib/templates/admin/admininvoicescontrolsoutput.tpl
+++ b/modules/addons/NFEioServiceInvoices/lib/templates/admin/admininvoicescontrolsoutput.tpl
@@ -2,19 +2,51 @@
     {if $data == 'Waiting'}
         <span class="label label-warning">Aguardando</span>
     {elseif $data == 'Created'}
-        <span class="label label-info">Processando</span>
+        <span class="label label-info">Criada</span>
     {elseif $data == 'Issued'}
         <span class="label label-success">Emitida</span>
     {elseif $data == 'Cancelled'}
         <span class="label label-danger">Cancelada</span>
     {elseif $data == 'Error'}
-        <span class="label label-danger">Falha ao Emitir</span>
+        <span class="label label-danger">Erro</span>
     {elseif $data == 'Error_cep'}
         <span class="label label-danger">CEP do cliente inválido</span>
     {elseif $data == 'None'}
-        <span class="label label-primary">Nenhum</span>
+        <span class="label label-primary">Não Disponível</span>
     {else}
         <span class="label label-danger">{$data}</span>
+    {/if}
+{/function}
+{*https://nfe.io/docs/https/nfeio/docs/documentacao/nota-fiscal-servico-eletronica/duvidas/como-saber-se-sua-nota-fiscal-de-servico-foi-emitida-pela-api/*}
+{function name=flowStatus}
+    {if $data == 'Issued'}
+        Nota emitida
+    {elseif $data == 'Cancelled'}
+        Nota cancelada
+    {elseif $data == 'waiting'}
+        Fila de emissão
+    {elseif $data == 'WaitingCalculateTaxes'}
+        Calculando impostos da nota
+    {elseif $data == 'CancelFailed'}
+        Nota não foi cancelada com sucesso
+    {elseif $data == 'IssueFailed'}
+        Emissão da nota sem sucesso
+    {elseif $data == 'PullFromCityHall'}
+        PullFromCityHall
+    {elseif $data == 'WaitingDefineRpsNumber'}
+        Definindo número de RPS da nota
+    {elseif $data == 'WaitingSend'}
+        Nota enviada para emissão na prefeitura e aguardando confirmação de recebimento da mesma
+    {elseif $data == 'WaitingSendCancel'}
+        Nota enviada para cancelamento na prefeitura e aguardando confirmação de recebimento da mesma
+    {elseif $data == 'WaitingReturn'}
+        Aguardando retorno da prefeitura com confirmação de nota emitida
+    {elseif $data == 'WaitingDownload'}
+        Aguardando download do PDF da nota
+    {elseif $data == 'waiting'}
+        Aguardando na fila para processamento
+    {else}
+        Não disponível
     {/if}
 {/function}
 
@@ -84,7 +116,7 @@
                             <td class="text-center">{$nota->nfe_id}</td>
                             <td class="text-center"><abbr title="{$nota->created_at|date_format:"%H:%M:%S"}">{$nota->created_at|date_format:"%d/%m/%Y"}</abbr></td>
                             <td class="text-center">{$nota->services_amount}</td>
-                            <td class="text-center"><abbr title="Status Flow: {$nota->flow_status}">{statusLabel data=$nota->status}</abbr></td>
+                            <td class="text-center"><abbr title="Status Flow: {flowStatus data=$nota->flow_status}">{statusLabel data=$nota->status}</abbr></td>
                             <td>
                                 <form action="" method="post" id="nfeio_frm_email_{$smarty.foreach.nf.iteration}">
                                     <input type="hidden" name="nfeiosi" value="email">

--- a/modules/addons/NFEioServiceInvoices/lib/templates/admin/index.tpl
+++ b/modules/addons/NFEioServiceInvoices/lib/templates/admin/index.tpl
@@ -4,21 +4,55 @@
   {if $data == 'Waiting'}
     <span class="label label-warning">Aguardando</span>
   {elseif $data == 'Created'}
-    <span class="label label-info">Processando</span>
+    <span class="label label-info">Criada</span>
   {elseif $data == 'Issued'}
     <span class="label label-success">Emitida</span>
   {elseif $data == 'Cancelled'}
     <span class="label label-danger">Cancelada</span>
   {elseif $data == 'Error'}
-    <span class="label label-danger">Falha ao Emitir</span>
+    <span class="label label-danger">Erro</span>
   {elseif $data == 'Error_cep'}
     <span class="label label-danger">CEP do cliente inválido</span>
   {elseif $data == 'None'}
-    <span class="label label-primary">Nenhum</span>
+    <span class="label label-primary">Não Disponível</span>
   {else}
-    <span class="label label-default">{$data}</span>
+    <span class="label label-danger">{$data}</span>
   {/if}
 {/function}
+
+{*https://nfe.io/docs/https/nfeio/docs/documentacao/nota-fiscal-servico-eletronica/duvidas/como-saber-se-sua-nota-fiscal-de-servico-foi-emitida-pela-api/*}
+{function name=flowStatus}
+  {if $data == 'Issued'}
+    Nota emitida
+  {elseif $data == 'Cancelled'}
+    Nota cancelada
+  {elseif $data == 'waiting'}
+    Fila de emissão
+  {elseif $data == 'WaitingCalculateTaxes'}
+    Calculando impostos da nota
+  {elseif $data == 'CancelFailed'}
+    Nota não foi cancelada com sucesso
+  {elseif $data == 'IssueFailed'}
+    Emissão da nota sem sucesso
+  {elseif $data == 'PullFromCityHall'}
+    PullFromCityHall
+  {elseif $data == 'WaitingDefineRpsNumber'}
+    Definindo número de RPS da nota
+  {elseif $data == 'WaitingSend'}
+    Nota enviada para emissão na prefeitura e aguardando confirmação de recebimento da mesma
+  {elseif $data == 'WaitingSendCancel'}
+    Nota enviada para cancelamento na prefeitura e aguardando confirmação de recebimento da mesma
+  {elseif $data == 'WaitingReturn'}
+    Aguardando retorno da prefeitura com confirmação de nota emitida
+  {elseif $data == 'WaitingDownload'}
+    Aguardando download do PDF da nota
+  {elseif $data == 'waiting'}
+    Aguardando na fila para processamento
+  {else}
+    Não disponível
+  {/if}
+{/function}
+
 {function name=disableButtonAction}
   {if $data == 'Cancelled' OR $data == 'Error' OR $data == 'IssueFailed'}
     disabled="true"
@@ -26,6 +60,11 @@
 {/function}
 {function name=disableGenerateButtonAction}
   {if $data != 'Cancelled'}
+    disabled="true"
+  {/if}
+{/function}
+{function name=disableCancelButtonAction}
+  {if $data == 'Cancelled'}
     disabled="true"
   {/if}
 {/function}
@@ -65,11 +104,11 @@
                       </a>
                     </td>
                     <td>R${$nota->services_amount}</td>
-                    <td class="text-center">{statusLabel data=$nota->status}</td>
+                    <td class="text-center"><abbr title="Status Flow: {flowStatus data=$nota->flow_status}">{statusLabel data=$nota->status}</abbr></td>
                     <td class="text-right">
                       <button {disableGenerateButtonAction data=$nota->status} onclick="goTo('{$modulelink}&action=reissueNf&invoice_id={$nota->invoice_id}', '_self');" class="btn btn-primary btn-sm" id="gnfe_generate">Reemitir NFSe</button>
                       <button onclick="goTo('https://app.nfe.io/companies/{$company_id}/service-invoices/{$nota->nfe_id}', '_blank');" formtarget="_blank" class="btn btn-success btn-sm" id="gnfe_view">Visualizar</button>
-                      <button {disableButtonAction data=$nota->status} onclick="goTo('{$modulelink}&action=cancelNf&invoice_id={$nota->invoice_id}', '_self');" class="btn btn-danger btn-sm" id="gnfe_cancel">Cancelar NFSe</button>
+                      <button {disableCancelButtonAction data=$nota->status} onclick="goTo('{$modulelink}&action=cancelNf&invoice_id={$nota->invoice_id}', '_self');" class="btn btn-danger btn-sm" id="gnfe_cancel">Cancelar NFSe</button>
                       <button {disableButtonAction data=$nota->status} onclick="goTo('{$modulelink}&action=legacyFunctions&gnfe_email={$nota->nfe_id}', '_self');" class="btn btn-info btn-sm" id="gnfe_email">Enviar e-mail</button>
                     </td>
                   </tr>


### PR DESCRIPTION
**Correções**

* Corrige callback para processar notas que falharam: Quando webhook da API enviava corpo de uma nota que falhou, o callback ignorava e não atualizava o status local;
* Melhora a exibição das mensagens de status na interface web para os administradores.