### PR TITLE
Atualização para emitir nota fiscal com base no valor total da fatura

### DIFF
--- a/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
+++ b/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
@@ -174,14 +174,9 @@ class Nfe
                 'service_code' => $serviceCode,
             ];
 
+            $invoiceData = \WHMCS\Billing\Invoice::find($invoiceId);
+            $itemsTotal = $invoiceData->total;
 
-            // percorre cada item para realizar as agregações e somatórias
-            foreach ($item as $value) {
-                // concatena todas as descrições dos itens
-                $itemsDescription = $itemsDescription . $value['itemDescription'] . "\n";
-                // soma os valores de cada item para o total da nota
-                $itemsTotal = $itemsTotal + $value['itemAmount'];
-            }
             // adiciona a descrição da nota no formato parametrizado
             $nfData['nfe_description'] = \NFEioServiceInvoices\Helpers\Invoices::generateNfServiceDescription($invoiceId, $itemsDescription);
             // adiciona o valor total calculado para os itens


### PR DESCRIPTION
Isso corrigi um Bug que eu estava enfrentando que era emitir a nota fiscal apenas com o valor de cada item, e aqui agora esta emitindo com base no valor total da fatura que inclui o valor de todos itens da fatura e também os valor adicionais como impostos etc..