### PR TITLE
corrige propriedades de colunas de timestamp

### DIFF
--- a/modules/addons/NFEioServiceInvoices/callback.php
+++ b/modules/addons/NFEioServiceInvoices/callback.php
@@ -150,8 +150,6 @@ if ((string)$nfe['nfe_id'] === (string)$nf_id and $nfe['status'] !== (string)$nf
         'environment' => $nfe['environment'],
         'flow_status' => $nf_flow_status,
         'pdf' => $nfe['pdf'],
-        'created_at' => $nfe['created_at'],
-        'updated_at' => date('Y-m-d H:i:s'),
     ];
 
     try {

--- a/modules/addons/NFEioServiceInvoices/lib/Configuration.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Configuration.php
@@ -283,5 +283,23 @@ final class Configuration extends \WHMCSExpert\mtLibs\process\AbstractConfigurat
              * @see https://github.com/nfe/whmcs-addon/issues/134
              */
         }
+
+        /**
+         * Atualiza as colunas de timestamp para a versão inferior a 2.1.8
+         * nas tabelas informadas.
+         *
+         * @see https://github.com/nfe/whmcs-addon/issues/156
+         */
+        if(version_compare($currentlyInstalledVersion, '2.1.8', 'le')) {
+
+            // atualiza o nome da coluna de timestamp para a tabela productcode
+            \NFEioServiceInvoices\Migrations\Migrations::changeProductCodeTimestampColumnsName();
+
+            // altera as colunas de timestamp para as tabelas
+            \NFEioServiceInvoices\Migrations\Migrations::migrateTimestampColumns('mod_nfeio_si_productcode');
+            \NFEioServiceInvoices\Migrations\Migrations::migrateTimestampColumns('mod_nfeio_si_serviceinvoices');
+            \NFEioServiceInvoices\Migrations\Migrations::migrateTimestampColumns('mod_nfeio_si_aliquots');
+
+        }
     }
 }

--- a/modules/addons/NFEioServiceInvoices/lib/Legacy/Functions.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Legacy/Functions.php
@@ -208,8 +208,6 @@ class Functions
                 'environment' => 'waiting',
                 'flow_status' => 'waiting',
                 'pdf' => 'waiting',
-                'created_at' => date('Y-m-d H:i:s'),
-                'updated_at' => 'waiting',
                 'rpsSerialNumber' => 'waiting',
                 'service_code' => $item['code_service'],
             ];
@@ -225,9 +223,9 @@ class Functions
                         $mount_item = floatval($item['amount']);
                         $mount = $mountDB + $mount_item;
 
-                        $update_nfe = Capsule::table($_tableName)->where('id', '=', $service_code_row[0]->id)->update(['services_amount' => $mount]);
+                        Capsule::table($_tableName)->where('id', '=', $service_code_row[0]->id)->update(['services_amount' => $mount]);
                     } else {
-                        $save_nfe = Capsule::table($_tableName)->insert($data);
+                        Capsule::table($_tableName)->insert($data);
                     }
                 } catch (\Exception $e) {
                     return $e->getMessage();
@@ -437,7 +435,7 @@ class Functions
         return $result;
     }
 
-    function gnfe_update_nfe($nfe, $user_id, $invoice_id, $pdf, $created_at, $updated_at, $id_gofasnfeio = false)
+    function gnfe_update_nfe($nfe, $user_id, $invoice_id, $pdf, $id_gofasnfeio = false)
     {
         $data = [
             'invoice_id' => $invoice_id,
@@ -448,8 +446,6 @@ class Functions
             'environment' => $nfe->environment,
             'flow_status' => $nfe->flowStatus,
             'pdf' => $pdf,
-            'created_at' => $created_at,
-            'updated_at' => $updated_at,
             'rpsSerialNumber' => $nfe->rpsSerialNumber,
             'rpsNumber' => $nfe->rpsNumber,
         ];

--- a/modules/addons/NFEioServiceInvoices/lib/Migrations/Migrations.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Migrations/Migrations.php
@@ -234,7 +234,7 @@ class Migrations
             $pdo = Capsule::connection()->getPdo();
             $pdo->beginTransaction();
             try {
-                $self = new static();
+                $self = new self();
                 $self->createAlterColumnTimestampStatement($pdo, 'created_at', 'CURRENT_TIMESTAMP', $tableName);
                 $self->createAlterColumnTimestampStatement($pdo, 'updated_at', 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $tableName);
                 if ($pdo->inTransaction()) {

--- a/modules/addons/NFEioServiceInvoices/lib/Migrations/Migrations.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Migrations/Migrations.php
@@ -200,4 +200,93 @@ class Migrations
 
         return false;
     }
+
+    /**
+     * Creates and executes an SQL statement to alter a column in the specified table.
+     *
+     * @param PDO $pdo The PDO object for database connection
+     * @param string $columnName The name of the column to be altered
+     * @param string $alterStatement The ALTER statement for the column
+     * @return void
+     */
+    private function createAlterColumnTimestampStatement($pdo, $columnName, $alterStatement, $tableName)
+    {
+        $statement = $pdo->prepare(
+            sprintf('ALTER TABLE %s CHANGE %s %s TIMESTAMP NOT NULL DEFAULT %s',
+                $tableName,
+                $columnName,
+                $columnName,
+                $alterStatement
+            )
+        );
+        $statement->execute();
+    }
+
+    /**
+     *
+     * Atualiza as colunas de timestamp na tabela de notas fiscais de serviço.
+     * Define a coluna `created_at` com o valor do timestamp atual, e
+     * a coluna `updated_at` com o valor do timestamp atual em caso de atualização.
+     */
+    public static function migrateTimestampColumns(string $tableName)
+    {
+        if (Capsule::schema()->hasTable($tableName)) {
+            $pdo = Capsule::connection()->getPdo();
+            $pdo->beginTransaction();
+            try {
+                $self = new static();
+                $self->createAlterColumnTimestampStatement($pdo, 'created_at', 'CURRENT_TIMESTAMP', $tableName);
+                $self->createAlterColumnTimestampStatement($pdo, 'updated_at', 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $tableName);
+                if ($pdo->inTransaction()) {
+                    $pdo->commit();
+                }
+            } catch (\Exception $e) {
+                logModuleCall(
+                    'nfeio_serviceinvoices',
+                    'upgradeServiceInvoicesTimestampColumns_error',
+                    $e->getMessage(),
+                    $e->getTraceAsString()
+                );
+                if ($pdo->inTransaction()) {
+                    $pdo->rollBack();
+                }
+
+            }
+        }
+    }
+
+    /**
+     * Altera as colunas da tabela mod_nfeio_si_productcode referente ao timestamp
+     * para created_at e updated_at.
+     *
+     * @return void
+     */
+    public static function changeProductCodeTimestampColumnsName()
+    {
+
+        if (Capsule::schema()->hasTable('mod_nfeio_si_productcode')) {
+
+            $pdo = Capsule::connection()->getPdo();
+            $pdo->beginTransaction();
+            try {
+                $st1 = $pdo->prepare('ALTER TABLE mod_nfeio_si_productcode CHANGE create_at created_at TIMESTAMP');
+                $st2 = $pdo->prepare('ALTER TABLE mod_nfeio_si_productcode CHANGE update_at updated_at TIMESTAMP');
+                $st1->execute();
+                $st2->execute();
+                if ($pdo->inTransaction()) {
+                    $pdo->commit();
+                }
+            } catch (\Exception $e) {
+                logModuleCall(
+                    'nfeio_serviceinvoices',
+                    'changeProductCodeTimestampColumnsName_error',
+                    $e->getMessage(),
+                    $e->getTraceAsString()
+                );
+                if ($pdo->inTransaction()) {
+                    $pdo->rollBack();
+                }
+            }
+        }
+    }
 }

--- a/modules/addons/NFEioServiceInvoices/lib/Models/Aliquots/Repository.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Models/Aliquots/Repository.php
@@ -81,8 +81,11 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
      */
     public function createAliquotsTable()
     {
-        if (!Capsule::schema()->hasTable($this->tableName)) {
-            Capsule::schema()->create(
+        $db = Capsule::connection();
+        $schema = Capsule::schema();
+
+        if (!$schema->hasTable($this->tableName)) {
+            $schema->create(
                 $this->tableName,
                 function ($table) {
                     $table->increments('id');
@@ -91,9 +94,13 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
                     // retenção de ISS
                     $table->float('iss_held', 5, 2)->nullable();
                     $table->timestamp('created_at')->useCurrent();
-                    $table->timestamp('updated_at')->useCurrentOnUpdate();
+                    $table->timestamp('updated_at')->useCurrent();
                 }
             );
+
+            // Adiciona a coluna updated_at com a configuração de auto update #156
+            $db->statement(sprintf('ALTER TABLE %s CHANGE updated_at updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $this->tableName));
+
         }
     }
 

--- a/modules/addons/NFEioServiceInvoices/lib/Models/Aliquots/Repository.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Models/Aliquots/Repository.php
@@ -90,8 +90,8 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
                     $table->string('code_service', 30);
                     // retenção de ISS
                     $table->float('iss_held', 5, 2)->nullable();
-                    $table->timestamp('created_at');
-                    $table->timestamp('updated_at');
+                    $table->timestamp('created_at')->useCurrent();
+                    $table->timestamp('updated_at')->useCurrentOnUpdate();
                 }
             );
         }

--- a/modules/addons/NFEioServiceInvoices/lib/Models/ProductCode/Repository.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Models/ProductCode/Repository.php
@@ -117,8 +117,8 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
                     $table->increments('id');
                     $table->integer('product_id');
                     $table->string('code_service', 30);
-                    $table->timestamp('create_at');
-                    $table->timestamp('update_at');
+                    $table->timestamp('created_at')->useCurrent();
+                    $table->timestamp('updated_at')->useCurrentOnUpdate();
                     $table->integer('ID_user');
                 }
             );

--- a/modules/addons/NFEioServiceInvoices/lib/Models/ProductCode/Repository.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Models/ProductCode/Repository.php
@@ -110,18 +110,25 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
      */
     public function createProductCodeTable()
     {
-        if (!Capsule::schema()->hasTable($this->tableName)) {
-            Capsule::schema()->create(
+        $db = Capsule::connection();
+        $schema = Capsule::schema();
+
+        if (!$schema->hasTable($this->tableName)) {
+            $schema->create(
                 $this->tableName,
                 function ($table) {
                     $table->increments('id');
                     $table->integer('product_id');
                     $table->string('code_service', 30);
                     $table->timestamp('created_at')->useCurrent();
-                    $table->timestamp('updated_at')->useCurrentOnUpdate();
+                    $table->timestamp('updated_at')->useCurrent();
                     $table->integer('ID_user');
                 }
             );
+
+            // Adiciona a coluna updated_at com a configuração de auto update #156
+            $db->statement(sprintf('ALTER TABLE %s CHANGE updated_at updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $this->tableName));
+
         }
     }
 

--- a/modules/addons/NFEioServiceInvoices/lib/Models/ServiceInvoices/Repository.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Models/ServiceInvoices/Repository.php
@@ -115,8 +115,8 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
                     $table->string('pdf');
                     $table->string('rpsSerialNumber');
                     $table->string('rpsNumber');
-                    $table->timestamp('created_at');
-                    $table->timestamp('updated_at');
+                    $table->timestamp('created_at')->useCurrent();
+                    $table->timestamp('updated_at')->useCurrentOnUpdate();
                     $table->string('service_code', 30)->nullable(true);
                     $table->string('tics')->nullable(true);
                 }

--- a/modules/addons/NFEioServiceInvoices/lib/Models/ServiceInvoices/Repository.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Models/ServiceInvoices/Repository.php
@@ -94,8 +94,11 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
      */
     public function createServiceInvoicesTable()
     {
-        if (!Capsule::schema()->hasTable($this->tableName)) {
-            Capsule::schema()->create(
+        $db = Capsule::connection();
+        $schema = Capsule::schema();
+
+        if (!$schema->hasTable($this->tableName)) {
+            $schema->create(
                 $this->tableName,
                 function ($table) {
                     // incremented id
@@ -116,12 +119,16 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
                     $table->string('rpsSerialNumber');
                     $table->string('rpsNumber');
                     $table->timestamp('created_at')->useCurrent();
-                    $table->timestamp('updated_at')->useCurrentOnUpdate();
+                    $table->timestamp('updated_at')->useCurrent();
                     $table->string('service_code', 30)->nullable(true);
                     $table->string('tics')->nullable(true);
                 }
             );
         }
+
+        // Adiciona a coluna updated_at com a configuração de auto update #156
+        $db->statement(sprintf('ALTER TABLE %s CHANGE updated_at updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $this->tableName));
+
     }
 
     /**

--- a/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
+++ b/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
@@ -410,7 +410,7 @@ class Nfe
         $nfeResponse = $this->legacyFunctions->gnfe_issue_nfe($postData);
 
         if (!$nfeResponse->message) {
-            $gnfe_update_nfe = $this->legacyFunctions->gnfe_update_nfe($nfeResponse, $clientId, $invoiceId, 'n/a', date('Y-m-d H:i:s'), date('Y-m-d H:i:s'), $nfDbId);
+            $this->legacyFunctions->gnfe_update_nfe($nfeResponse, $clientId, $invoiceId, 'n/a', $nfDbId);
             logModuleCall('nfeio_serviceinvoices', 'nf_emit', $postData, $nfeResponse);
         } else {
             logModuleCall('nfeio_serviceinvoices', 'nf_emit_error', $postData, $nfeResponse);


### PR DESCRIPTION
Esta atualização modifica como as colunas de registro de data e hora de criação e atualização são manipuladas no módulo NFEioServiceInvoices. Agora, as colunas 'created_at' e 'updated_at' são gerenciadas automaticamente pelo banco de dados, evitando a necessidade de atualizá-las manualmente no código. Além disso, foi implementada uma migração para atualizar as colunas em questão nas tabelas existentes.

ref: #156