### PR TITLE
fix: erro RNG6110 Schema XML no bloco IbsCbs para empresas sem códigos IBS/CBS

### DIFF
--- a/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
+++ b/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
@@ -625,7 +625,7 @@ class Nfe
             'description' => $description,
             'servicesAmount' => $amount,
             'externalId' => $externalId,
-            'nbsCode' => $nbsCode,
+            'nbsCode' => !empty($nbsCode) ? $nbsCode : null,
             'borrower' => [
                 'federalTaxNumber' => $customer['document'],
                 'municipalTaxNumber' => $customer['insc_municipal'],
@@ -646,8 +646,8 @@ class Nfe
                 ]
             ],
             'IbsCbs' => [
-                'operationIndicator' => $operationCode,
-                'classCode' => $classCode,
+                'operationIndicator' => !empty($operationCode) ? $operationCode : null,
+                'classCode' => !empty($classCode) ? $classCode : null,
             ]
         ];
 


### PR DESCRIPTION
## Problema

Empresas que **não possuem códigos IBS/CBS** (como microempresas) recebem o seguinte erro ao emitir NFSe:

> **RNG6110 Falha Schema Xml.** The element 'IBSCBS' in namespace 'http://www.sped.fazenda.gov.br/nfse' has incomplete content. List of possible elements expected: 'finNFSe' in namespace 'http://www.sped.fazenda.gov.br/nfse'.

## Causa raiz

No `Admin/Controller.php` (linhas 366-368), ao salvar a configuração da empresa, os campos `nbs_code`, `operation_indicator` e `class_code` são convertidos com `(string)`, o que transforma `null` em `""` (string vazia) no banco de dados.

Quando o método `emit()` em `Nfe.php` monta o payload JSON para a API, esses valores vazios `""` são enviados dentro do objeto `IbsCbs`. A API da NFE.io interpreta strings vazias como valores presentes e tenta construir o bloco XML `IBSCBS`, exigindo o campo obrigatório `finNFSe` — que o módulo não envia — causando a falha de validação do schema.

## Correção

No método `emit()` (`lib/NFEio/Nfe.php`), os campos `nbsCode`, `operationIndicator` e `classCode` agora são verificados com `!empty()`. Strings vazias são convertidas para `null`, fazendo a API tratar o bloco IBSCBS como opcional.

**Antes:**
```php
'nbsCode' => $nbsCode,
'IbsCbs' => [
    'operationIndicator' => $operationCode,
    'classCode' => $classCode,
]
```

**Depois:**
```php
'nbsCode' => !empty($nbsCode) ? $nbsCode : null,
'IbsCbs' => [
    'operationIndicator' => !empty($operationCode) ? $operationCode : null,
    'classCode' => !empty($classCode) ? $classCode : null,
]
```

## Teste

Testado com empresa configurada sem códigos IBS/CBS (microempresa). A NFSe é emitida com sucesso após a correção, enviando o payload conforme esperado pela API:

```json
"nbsCode": null,
"IbsCbs": {
    "operationIndicator": null,
    "classCode": null
}
```