### PR TITLE
fix: webhook não é criado automaticamente na primeira emissão de NFSe

### DIFF
--- a/modules/addons/NFEioServiceInvoices/lib/Legacy/Functions.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Legacy/Functions.php
@@ -151,21 +151,33 @@ class Functions
     function gnfe_issue_nfe($postfields, $companyId)
     {
         $webhook_url = Addon::getCallBackPath();
-        $webhook_id = $this->gnfe_config('webhook_id');
         $_storageKey = Addon::I()->configuration()->storageKey;
         $storage = new Storage($_storageKey);
         $nfeio = new \NFEioServiceInvoices\NFEio\Nfe();
 
+        // Recupera webhook_id de forma segura (pode não existir no banco)
+        $webhook_id = $storage->get('webhook_id');
 
         // Verifica se o webhook existe e é válido, senão cria
-        $webhook = $webhook_id ? $nfeio->getWebhook($webhook_id) : null;
-        if (!$webhook || $webhook->hooks->url !== $webhook_url) {
+        $webhook = !empty($webhook_id) ? $nfeio->getWebhook($webhook_id) : null;
+
+        // Se getWebhook retornou erro (array), trata como inexistente
+        if (is_array($webhook) && isset($webhook['error'])) {
+            $webhook = null;
+        }
+
+        $webhookUrlMatch = is_object($webhook) && isset($webhook->hooks->url) && $webhook->hooks->url === $webhook_url;
+
+        if (!$webhook || !$webhookUrlMatch) {
             $newHook = $nfeio->createWebhook($webhook_url);
-            if (!$newHook) {
-                return (object)['message' => 'Erro ao criar novo webhook'];
+
+            // Verifica se createWebhook retornou erro (array) ou falhou
+            if (!$newHook || (is_array($newHook) && isset($newHook['error']))) {
+                logModuleCall('nfeio_serviceinvoices', 'webhook_create_failed', $webhook_url, $newHook);
+            } elseif (is_object($newHook) && isset($newHook->hooks->id)) {
+                $storage->set('webhook_id', (string) $newHook->hooks->id);
+                $storage->set('webhook_secret', (string) $newHook->hooks->secret);
             }
-            $storage->set('webhook_id', (string) $newHook->hooks->id);
-            $storage->set('webhook_secret', (string) $newHook->hooks->secret);
         }
 
 


### PR DESCRIPTION
## Problema

O webhook deveria ser criado automaticamente na primeira emissão de nota fiscal, mas permanece como "Não configurado" mesmo após emissões bem-sucedidas.

## Causa raiz

Três bugs no método `gnfe_issue_nfe()` em `lib/Legacy/Functions.php` impedem a criação:

### Bug 1: `gnfe_config('webhook_id')` causa Fatal Error em PHP 8+

```php
// ANTES (linha 154)
$webhook_id = $this->gnfe_config('webhook_id');
```

O método `gnfe_config()` acessa `->get(['value'])[0]->value` diretamente. Como `webhook_id` **não está** no `fieldDeclaration` do módulo, a setting não existe em `tbladdonmodules`. O resultado é uma Collection vazia, e `null->value` causa Fatal Error no PHP 8+ (`Attempt to read property "value" on null`), abortando a função inteira.

### Bug 2: Retorno de erro de `createWebhook()` não é detectado

```php
// ANTES (linhas 163-168)
$newHook = $nfeio->createWebhook($webhook_url);
if (!$newHook) {  // ← Não detecta arrays de erro
    return (object)['message' => 'Erro ao criar novo webhook'];
}
$storage->set('webhook_id', (string) $newHook->hooks->id);  // ← Crash: ->hooks em array
```

Quando `createWebhook()` falha (exceção), retorna `['error' => 'mensagem']`. A verificação `if (!$newHook)` não detecta arrays não-vazios (truthy em PHP). O código prossegue tentando acessar `$newHook->hooks->id` em um array, causando crash silencioso.

### Bug 3: Retorno de erro de `getWebhook()` não é tratado

```php
// ANTES (linha 162)
if (!$webhook || $webhook->hooks->url !== $webhook_url) {
```

Se `getWebhook()` retorna `['error' => '...']`, `$webhook->hooks->url` tenta acessar propriedade de objeto em array → crash.

## Correção

```php
// DEPOIS
$webhook_id = $storage->get('webhook_id');  // Leitura segura via Storage

$webhook = !empty($webhook_id) ? $nfeio->getWebhook($webhook_id) : null;

// Trata retorno de erro como webhook inexistente
if (is_array($webhook) && isset($webhook['error'])) {
    $webhook = null;
}

$webhookUrlMatch = is_object($webhook) && isset($webhook->hooks->url)
    && $webhook->hooks->url === $webhook_url;

if (!$webhook || !$webhookUrlMatch) {
    $newHook = $nfeio->createWebhook($webhook_url);

    if (!$newHook || (is_array($newHook) && isset($newHook['error']))) {
        logModuleCall('nfeio_serviceinvoices', 'webhook_create_failed', ...);
    } elseif (is_object($newHook) && isset($newHook->hooks->id)) {
        $storage->set('webhook_id', (string) $newHook->hooks->id);
        $storage->set('webhook_secret', (string) $newHook->hooks->secret);
    }
}
```

### Mudanças principais:

1. Substituído `gnfe_config('webhook_id')` por `$storage->get('webhook_id')` — retorna `null` de forma segura
2. Verificação de tipo com `is_array()` + `isset()` para detectar retornos de erro
3. Verificação com `is_object()` + `isset()` antes de acessar `->hooks->id`
4. Falha no webhook não bloqueia mais a emissão da nota (antes fazia `return`)
5. Log registrado quando criação do webhook falha, para diagnóstico

## Teste

Testado com módulo em ambiente onde `webhook_id` não existia em `tbladdonmodules`. Após a correção, o webhook é criado com sucesso na primeira emissão.