### PR TITLE
fix: webhook HMAC validation uses base64_decode on hex signature

### DIFF
--- a/modules/addons/NFEioServiceInvoices/lib/Helpers/Validations.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Helpers/Validations.php
@@ -65,10 +65,8 @@ class Validations
      */
     public static function webhookHashValid(string $secret, $payload, string $signature, string $algo = "sha1"): bool
     {
-        $instance = new self();
-        $hash = $instance->webhookComputeHash($algo, $secret, $payload);
-        $signature = base64_decode($signature);
-        return hash_equals($hash, $signature);
+        $computed_hex = hash_hmac($algo, $payload, utf8_encode($secret));
+        return hash_equals(strtolower($computed_hex), strtolower($signature));
     }
 
     /**


### PR DESCRIPTION
## Summary

- The NFE.io API sends `x-hub-signature` as a **hex-encoded** HMAC-SHA1 hash (e.g. `sha1=AD0AAAB084705FD124A1EF3483A86A67B6D78CDF`)
- `webhookHashValid()` was calling `base64_decode()` on this hex string before comparing it with `hex2bin()` of the computed hash
- Since `base64_decode` of a hex string produces completely different bytes than `hex2bin` of the computed hash, **every webhook callback fails** with "Assinatura inválida"
- Fix: compare both hashes directly as hex strings (case-insensitive) using `hash_equals(strtolower(...), strtolower(...))`

## Before (broken)
```php
$hash = $instance->webhookComputeHash($algo, $secret, $payload); // returns hex2bin(...)
$signature = base64_decode($signature); // wrong: treats hex as base64
return hash_equals($hash, $signature); // never matches
```

## After (fixed)
```php
$computed_hex = hash_hmac($algo, $payload, utf8_encode($secret));
return hash_equals(strtolower($computed_hex), strtolower($signature));
```

## Test plan
- [x] Verified in production: computed and received hashes now match correctly
- [x] Confirmed webhook callbacks pass signature validation after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)