### PR TITLE
fix(webhook): migrate to API v2 (api.nfse.io) with correct schema and NFS-e filters

### DIFF
--- a/modules/addons/NFEioServiceInvoices/callback.php
+++ b/modules/addons/NFEioServiceInvoices/callback.php
@@ -44,6 +44,12 @@ if (!Validations::webhookHashValid($secret, $body, $signature)) {
 
 $payload = json_decode($body, true);
 
+// v2 envelopa o invoice em {"action": "<event>", "payload": {<invoice fields>}}.
+// Desembrulhamos pra manter a leitura por field name compatível com v1.
+if (is_array($payload) && isset($payload['payload']) && is_array($payload['payload'])) {
+    $payload = $payload['payload'];
+}
+
 if (!is_array($payload) || !isset($payload['id'], $payload['status'], $payload['flowStatus'], $payload['environment'])) {
     logModuleCall('nfeio_serviceinvoices', 'callback_error', 'Payload inválido', ['body' => $payload]);
     http_response_code(400);

--- a/modules/addons/NFEioServiceInvoices/lib/Admin/Controller.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Admin/Controller.php
@@ -1216,7 +1216,7 @@ class Controller
         }
 
         try {
-            // Instanciar classe Nfe e buscar webhook na API
+            // Instanciar classe Nfe e buscar webhook na API (api.nfse.io/v2)
             $nfe = new \NFEioServiceInvoices\NFEio\Nfe();
             $webhook = $nfe->getWebhook($webhookId);
 
@@ -1239,9 +1239,11 @@ class Controller
                 return;
             }
 
-            // Webhook encontrado - validar configuração
+            // Webhook encontrado - extrair dados da resposta
+            // A API v2 retorna em ->webHook->{prop} (camelCase), URL fica em ->uri
             $callbackUrl = Addon::getCallBackPath();
-            $apiWebhookUrl = isset($webhook->hooks->url) ? $webhook->hooks->url : null;
+            $webhookData = isset($webhook->webHook) ? $webhook->webHook : (isset($webhook->hooks) ? $webhook->hooks : $webhook);
+            $apiWebhookUrl = isset($webhookData->uri) ? $webhookData->uri : (isset($webhookData->url) ? $webhookData->url : null);
 
             // Verificar consistência de URL
             if ($apiWebhookUrl !== $callbackUrl) {
@@ -1267,7 +1269,7 @@ class Controller
             }
 
             // Verificar status do webhook (ativo/inativo/deleted)
-            $webhookStatus = isset($webhook->hooks->status) ? $webhook->hooks->status : 'unknown';
+            $webhookStatus = isset($webhookData->status) ? strtolower($webhookData->status) : 'unknown';
             if (in_array(strtolower($webhookStatus), ['deleted', 'disabled', 'inactive'])) {
                 logModuleCall(
                     'nfeio_serviceinvoices',

--- a/modules/addons/NFEioServiceInvoices/lib/Helpers/Validations.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Helpers/Validations.php
@@ -65,10 +65,11 @@ class Validations
      */
     public static function webhookHashValid(string $secret, $payload, string $signature, string $algo = "sha1"): bool
     {
-        $instance = new self();
-        $hash = $instance->webhookComputeHash($algo, $secret, $payload);
-        $signature = base64_decode($signature);
-        return hash_equals($hash, $signature);
+        // NFE.io envia X-Hub-Signature como HMAC em hexadecimal (ex: "sha1=AD0A...CDF").
+        // O callback já remove o prefixo "<algo>=" antes de passar pra cá, então $signature
+        // é hex puro. Comparamos hex contra hex em hash_equals com normalização de case.
+        $computed_hex = hash_hmac($algo, $payload, utf8_encode($secret));
+        return hash_equals(strtolower($computed_hex), strtolower($signature));
     }
 
     /**

--- a/modules/addons/NFEioServiceInvoices/lib/Legacy/Functions.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Legacy/Functions.php
@@ -159,13 +159,14 @@ class Functions
 
         // Verifica se o webhook existe e é válido, senão cria
         $webhook = $webhook_id ? $nfeio->getWebhook($webhook_id) : null;
-        if (!$webhook || $webhook->hooks->url !== $webhook_url) {
+        if (!$webhook || is_array($webhook) && isset($webhook["error"]) || (isset($webhook->hooks->url) && $webhook->hooks->url !== $webhook_url)) {
             $newHook = $nfeio->createWebhook($webhook_url);
-            if (!$newHook) {
-                return (object)['message' => 'Erro ao criar novo webhook'];
+            if (!$newHook || is_array($newHook) && isset($newHook["error"]) || !isset($newHook->hooks)) {
+                logModuleCall("nfeio_serviceinvoices", "create_webhook_skip", "Falha ao criar webhook, mantendo configuração atual", $newHook);
+            } else {
+                $storage->set("webhook_id", (string) $newHook->hooks->id);
+                $storage->set("webhook_secret", (string) $newHook->hooks->secret);
             }
-            $storage->set('webhook_id', (string) $newHook->hooks->id);
-            $storage->set('webhook_secret', (string) $newHook->hooks->secret);
         }
 
 

--- a/modules/addons/NFEioServiceInvoices/lib/Legacy/Functions.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Legacy/Functions.php
@@ -158,14 +158,25 @@ class Functions
 
 
         // Verifica se o webhook existe e é válido, senão cria
+        // API v2 retorna: {"webHook": {"id":..., "uri":..., "secret":..., "status":...}}
         $webhook = $webhook_id ? $nfeio->getWebhook($webhook_id) : null;
-        if (!$webhook || is_array($webhook) && isset($webhook["error"]) || (isset($webhook->hooks->url) && $webhook->hooks->url !== $webhook_url)) {
+        $webhookData = null;
+        if ($webhook && !is_array($webhook)) {
+            $webhookData = isset($webhook->webHook) ? $webhook->webHook : (isset($webhook->hooks) ? $webhook->hooks : null);
+        }
+        $currentUri = $webhookData && isset($webhookData->uri) ? $webhookData->uri : ($webhookData && isset($webhookData->url) ? $webhookData->url : null);
+
+        if (!$webhook || is_array($webhook) && isset($webhook['error']) || ($currentUri && $currentUri !== $webhook_url)) {
             $newHook = $nfeio->createWebhook($webhook_url);
-            if (!$newHook || is_array($newHook) && isset($newHook["error"]) || !isset($newHook->hooks)) {
-                logModuleCall("nfeio_serviceinvoices", "create_webhook_skip", "Falha ao criar webhook, mantendo configuração atual", $newHook);
+            $newHookData = null;
+            if ($newHook && !is_array($newHook)) {
+                $newHookData = isset($newHook->webHook) ? $newHook->webHook : (isset($newHook->hooks) ? $newHook->hooks : null);
+            }
+            if (!$newHookData || !isset($newHookData->id)) {
+                logModuleCall('nfeio_serviceinvoices', 'create_webhook_skip', 'Falha ao criar webhook, mantendo configuração atual', $newHook);
             } else {
-                $storage->set("webhook_id", (string) $newHook->hooks->id);
-                $storage->set("webhook_secret", (string) $newHook->hooks->secret);
+                $storage->set('webhook_id', (string) $newHookData->id);
+                $storage->set('webhook_secret', (string) $newHookData->secret);
             }
         }
 

--- a/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
+++ b/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
@@ -949,7 +949,7 @@ class Nfe
      * @param int $timeout Tempo limite em segundos (padrão: 5).
      * @return array Array com 'response', 'error' e 'info'.
      */
-    private function executeWebhookCurl($uri, $method = 'GET', $data = null, $timeout = 5)
+    private function executeWebhookCurl($uri, $method = 'GET', $data = null, $timeout = 30)
     {
         $headers = [
             'Content-Type: application/json',

--- a/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
+++ b/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
@@ -990,14 +990,24 @@ class Nfe
     {
         // Schema v2: payload envelopado em `webHook`, campo `uri` (não `url`),
         // `contentType` aceita apenas "json" | "form-urlencoded".
-        // `filters` é omitido para receber todos os eventos da conta — o callback
-        // valida o payload e descarta o que não for NFS-e.
+        // `filters` restringe a entrega ao ciclo de NFS-e (emissão + cancelamento);
+        // event types validados via GET /v2/webhooks/eventTypes.
         $data = [
             'webHook' => [
                 'uri' => $url,
                 'contentType' => 'json',
                 'secret' => Validations::generateSecretKey(),
                 'status' => 'active',
+                'filters' => [
+                    'service_invoice.issued',
+                    'service_invoice.issued_successfully',
+                    'service_invoice.issued_error',
+                    'service_invoice.issued_failed',
+                    'service_invoice.cancelled',
+                    'service_invoice.cancelled_successfully',
+                    'service_invoice.cancelled_error',
+                    'service_invoice.cancelled_failed',
+                ],
             ],
         ];
 

--- a/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
+++ b/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
@@ -941,15 +941,53 @@ class Nfe
     }
 
     /**
+     * Executa uma requisição cURL para a API de Webhooks da NFE.io (api.nfse.io/v2).
+     *
+     * @param string $uri O endpoint URI (ex: 'webhooks' ou 'webhooks/{id}').
+     * @param string $method O método HTTP (padrão: 'GET').
+     * @param array|null $data Dados para o corpo da requisição (POST/PUT).
+     * @param int $timeout Tempo limite em segundos (padrão: 5).
+     * @return array Array com 'response', 'error' e 'info'.
+     */
+    private function executeWebhookCurl($uri, $method = 'GET', $data = null, $timeout = 5)
+    {
+        $headers = [
+            'Content-Type: application/json',
+            'Accept: application/json',
+            'Authorization: ' . $this->storage->get('api_key'),
+        ];
+        $curl = curl_init();
+        curl_setopt($curl, CURLOPT_URL, 'https://api.nfse.io/v2/' . $uri);
+        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_TIMEOUT, $timeout);
+
+        if ($method === 'POST' || $method === 'PUT') {
+            curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($data));
+        }
+
+        $response = curl_exec($curl);
+        $error = curl_error($curl);
+        $info = curl_getinfo($curl);
+        curl_close($curl);
+
+        return [
+            'response' => $response,
+            'error' => $error,
+            'info' => $info,
+        ];
+    }
+
+    /**
      * Cria um webhook na NFE.io para receber eventos específicos.
+     * Utiliza a API v2 em api.nfse.io/v2/webhooks (sem company scope).
      *
      * @param string $url URL que receberá as notificações do webhook.
-     * @return \NFe_Webhook|array Retorna a instância do webhook criado ou um array com chave 'error' em caso de falha.
-     * @throws \Exception
+     * @return object|array Retorna o objeto do webhook criado ou um array com chave 'error' em caso de falha.
      */
     public function createWebhook($url)
     {
-        $this->apiAuth();
         $data = [
             'url' => $url,
             'contentType' => 'application/json',
@@ -958,35 +996,49 @@ class Nfe
             'status' => 'active',
         ];
 
-        try {
-            $hook = \NFe_Webhook::create($data);
-            logModuleCall('nfeio_serviceinvoices', 'create_webhook', $data, $hook);
-            return $hook;
-        } catch (\Exception $exception) {
-            logModuleCall('nfeio_serviceinvoices', 'create_webhook_error', $data, $exception->getMessage());
-            return ['error' => $exception->getMessage()];
+        $result = $this->executeWebhookCurl('webhooks', 'POST', $data);
+
+        if ($result['error']) {
+            logModuleCall('nfeio_serviceinvoices', 'create_webhook_error', $data, $result);
+            return ['error' => $result['error']];
         }
+
+        $decoded = json_decode($result['response']);
+
+        if ($result['info']['http_code'] >= 400 || !$decoded) {
+            logModuleCall('nfeio_serviceinvoices', 'create_webhook_error', $data, $result);
+            return ['error' => 'HTTP ' . $result['info']['http_code'] . ': ' . $result['response']];
+        }
+
+        logModuleCall('nfeio_serviceinvoices', 'create_webhook', $data, $decoded);
+        return $decoded;
     }
 
     /**
      * Recupera um webhook existente na NFE.io.
+     * Utiliza a API v2 em api.nfse.io/v2/webhooks/{id} (sem company scope).
      *
      * @param string $webhookId ID do webhook a ser buscado.
-     * @return \NFe_Webhook|array Retorna a instância do webhook ou um array com chave 'error' em caso de falha.
+     * @return object|array Retorna o objeto do webhook ou um array com chave 'error' em caso de falha.
      */
     public function getWebhook(string $webhookId)
     {
-        $this->apiAuth();
+        $result = $this->executeWebhookCurl('webhooks/' . $webhookId);
 
-        try {
-            $webhook = \NFe_Webhook::fetch($webhookId);
-            logModuleCall('nfeio_serviceinvoices', 'get_webhook', $webhookId, $webhook);
-            return $webhook;
-        } catch (\Exception $e) {
-            $error = $e->getMessage();
-            logModuleCall('nfeio_serviceinvoices', 'get_webhook_error', $webhookId, $error);
-            return ['error' => $error];
+        if ($result['error']) {
+            logModuleCall('nfeio_serviceinvoices', 'get_webhook_error', ['webhook_id' => $webhookId], $result);
+            return ['error' => $result['error']];
         }
+
+        $decoded = json_decode($result['response']);
+
+        if ($result['info']['http_code'] >= 400 || !$decoded) {
+            logModuleCall('nfeio_serviceinvoices', 'get_webhook_error', ['webhook_id' => $webhookId], $result);
+            return ['error' => 'HTTP ' . $result['info']['http_code'] . ': ' . $result['response']];
+        }
+
+        logModuleCall('nfeio_serviceinvoices', 'get_webhook', ['webhook_id' => $webhookId], $decoded);
+        return $decoded;
     }
 
     /**

--- a/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
+++ b/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
@@ -625,7 +625,7 @@ class Nfe
             'description' => $description,
             'servicesAmount' => $amount,
             'externalId' => $externalId,
-            'nbsCode' => $nbsCode,
+            'nbsCode' => !empty($nbsCode) ? $nbsCode : null,
             'borrower' => [
                 'federalTaxNumber' => $customer['document'],
                 'municipalTaxNumber' => $customer['insc_municipal'],
@@ -646,8 +646,8 @@ class Nfe
                 ]
             ],
             'IbsCbs' => [
-                'operationIndicator' => $operationCode,
-                'classCode' => $classCode,
+                'operationIndicator' => !empty($operationCode) ? $operationCode : null,
+                'classCode' => !empty($classCode) ? $classCode : null,
             ]
         ];
 

--- a/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
+++ b/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
@@ -988,12 +988,17 @@ class Nfe
      */
     public function createWebhook($url)
     {
+        // Schema v2: payload envelopado em `webHook`, campo `uri` (não `url`),
+        // `contentType` aceita apenas "json" | "form-urlencoded".
+        // `filters` é omitido para receber todos os eventos da conta — o callback
+        // valida o payload e descarta o que não for NFS-e.
         $data = [
-            'url' => $url,
-            'contentType' => 'application/json',
-            'secret' => Validations::generateSecretKey(),
-            'events' => ['issue', 'cancel', 'WaitingCalculateTaxes'],
-            'status' => 'active',
+            'webHook' => [
+                'uri' => $url,
+                'contentType' => 'json',
+                'secret' => Validations::generateSecretKey(),
+                'status' => 'active',
+            ],
         ];
 
         $result = $this->executeWebhookCurl('webhooks', 'POST', $data);


### PR DESCRIPTION
## Summary

Migra a integração de webhooks do módulo para a API v2 da NFE.io (`api.nfse.io/v2/webhooks`), substituindo o endpoint v1 descontinuado (`api.nfe.io/v1/hooks` → 404). Continua e finaliza o trabalho iniciado em #191 por @ianchamba, corrigindo o schema de request da criação, validação de HMAC e parsing do envelope v2 no callback.

Supersedes #190 e #191.

## Background

PR #191 trocou o endpoint para v2 mas mantinha o payload no schema v1 (flat, com `url`/`events`), o que fazia a criação de webhook falhar em runtime mesmo com a URL correta. Em paralelo, #190 (também de @ianchamba) identificou um bug pré-existente na comparação do HMAC que rejeitava todo callback com 403, e em validação runtime descobrimos que v2 envelopa o invoice em `{action, payload}`, exigindo unwrap antes da validação de campos.

Este PR consolida os trabalhos relacionados (3 commits do @ianchamba preservados com autoria + 4 commits adicionais) e fecha o ciclo de habilitação da v2.

## Changes (continuação do #191)

### `lib/NFEio/Nfe.php` — `createWebhook()`
- Payload migrado para schema v2: envelope `webHook`, `uri` (não `url`), `contentType: "json"` (enum `json|form-urlencoded`, não `application/json`).
- Adicionados `filters` específicos do ciclo NFS-e — substituem o trio v1 (`issue`/`cancel`/`WaitingCalculateTaxes`):
  - `service_invoice.issued`, `issued_successfully`, `issued_error`, `issued_failed`
  - `service_invoice.cancelled`, `cancelled_successfully`, `cancelled_error`, `cancelled_failed`
- Event types confirmados via `GET /v2/webhooks/eventTypes`. `WaitingCalculateTaxes` deixou de existir em v2 e foi absorvido pelos estados intermediários de `issued.*`.

### `lib/Helpers/Validations.php` — `webhookHashValid()` (incorpora #190)
- NFE.io envia `X-Hub-Signature` como HMAC em hexadecimal (`sha1=<hex>`), conforme [doc oficial](https://nfe.io/docs/documentacao/webhooks/duvidas-frequentes/).
- O código original aplicava `base64_decode()` na assinatura hex e comparava contra `hex2bin(hash_hmac(...))` (bytes raw) — `base64_decode` numa string hex produz bytes matematicamente diferentes, fazendo `hash_equals` nunca casar. Todo callback retornava 403.
- Fix: comparar hex vs hex em `hash_equals` com normalização de case. Crédito original a @ianchamba (`Co-authored-by`).

### `callback.php` — unwrap do envelope v2
- Webhook v2 entrega notificações no formato `{"action": "<event>", "payload": {<invoice fields>}}`. O callback esperava os campos na raiz (formato v1) e rejeitava todo payload v2 como "Payload inválido" com HTTP 400.
- Desembrulha o envelope quando presente, mantendo retrocompatibilidade. Confirmado via payload real capturado em ambiente Development.

### Originalmente em #191 (preservado neste PR)
- `lib/NFEio/Nfe.php`: `executeWebhookCurl()` para chamadas diretas a `api.nfse.io/v2`, `getWebhook()` reescrito para v2 (sem company scope), timeout aumentado para 30s.
- `lib/Legacy/Functions.php`: parsing da resposta v2 (`webHook->id/secret/uri`) e preservação do secret existente em caso de falha de criação.
- `lib/Admin/Controller.php`: `verifyWebhook()` lendo `webHook->uri/status` da resposta v2.

## Migração v1→v2 automática

Webhooks v1 antigos armazenados em `webhook_id` retornam erro ao serem consultados em v2 → `Legacy/Functions::gnfe_issue_nfe` detecta o erro → cria webhook novo via v2 → grava novo `webhook_id`+`webhook_secret`. Sem ação manual necessária.

## Test plan

- [x] Emitir NFS-e em ambiente com webhook v1 antigo registrado → verificar criação automática de webhook v2.
- [x] Verificar webhook na aba "Sobre" do admin → resposta deve ser parseada como `webHook->uri/status`.
- [x] Emitir NFS-e e confirmar callback recebido com payload válido (sem 400 "Payload inválido", sem 403 "Assinatura inválida").
- [x] Cancelar NFS-e e confirmar callback de cancelamento.
- [x] ~~Forçar falha de criação de webhook → confirmar que `webhook_secret` existente é preservado (não sobrescrito com vazio).~~ **Coberto por inspeção de código** ([Legacy/Functions.php:174-180](https://github.com/nfe/whmcs-addon/blob/fix/webhook-api-v2-endpoint/modules/addons/NFEioServiceInvoices/lib/Legacy/Functions.php#L174-L180)): o `storage->set('webhook_secret', ...)` está dentro do branch `else` do guard `if (!$newHookData || !isset($newHookData->id))`, e `$newHookData->id` só é preenchido quando `createWebhook` retorna objeto com envelope `webHook.id` válido. Em qualquer falha (`['error' => ...]`, HTTP ≥400, JSON malformado), o branch `if` registra `create_webhook_skip` e a escrita no storage é literalmente skipada — não há caminho de código que sobrescreva o secret com valor vazio.

Closes #190
Closes #191
