### PR TITLE
feat: atualizar automaticamente status de notas Criadas via cron

### DIFF
--- a/modules/addons/NFEioServiceInvoices/lib/Admin/Controller.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Admin/Controller.php
@@ -502,6 +502,7 @@ class Controller
         //$footer = isset($post['footer']) ? $post['footer'] : ' ';
         $iss_held = isset($post['iss_held']) ? $post['iss_held'] : 0;
         $discount_items = isset($post['discount_items']) ? $post['discount_items'] : '';
+        $auto_refresh_created_status = isset($post['auto_refresh_created_status']) ? $post['auto_refresh_created_status'] : '';
 
         // verifica cada campo e realiza a inserção das configurações no banco
         try {
@@ -531,6 +532,8 @@ class Controller
             $storage->set('iss_held', $iss_held);
             // discount_items
             $storage->set('discount_items', $discount_items);
+            // auto_refresh_created_status
+            $storage->set('auto_refresh_created_status', $auto_refresh_created_status);
 
             if ($rps_number) {
                 $storage->set('rps_number', $rps_number);

--- a/modules/addons/NFEioServiceInvoices/lib/Hooks/AfterCronJob.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Hooks/AfterCronJob.php
@@ -77,5 +77,62 @@ class AfterCronJob
             }
 
         }
+
+        if ($storage->get('auto_refresh_created_status') === 'on') {
+            $this->refreshCreatedInvoicesStatus();
+        }
+    }
+
+    private function refreshCreatedInvoicesStatus()
+    {
+        $serviceInvoicesTable = $this->serviceInvoicesRepo->tableName();
+
+        $createdInvoices = Capsule::table($serviceInvoicesTable)
+            ->where('status', '=', 'Created')
+            ->whereNotNull('nfe_id')
+            ->where('nfe_id', '!=', 'waiting')
+            ->orderBy('updated_at', 'asc')
+            ->limit(5)
+            ->get();
+
+        $totalCreated = count($createdInvoices);
+
+        logModuleCall(
+            'nfeio_serviceinvoices',
+            'hook_aftercronjob_refresh_created',
+            "{$totalCreated} nota(s) com status Created para atualizar",
+            $createdInvoices
+        );
+
+        if ($totalCreated === 0) {
+            return;
+        }
+
+        foreach ($createdInvoices as $invoice) {
+            $apiResponse = $this->nf->fetchNf($invoice->nfe_id, $invoice->company_id);
+
+            if (is_array($apiResponse) && isset($apiResponse['error'])) {
+                logModuleCall(
+                    'nfeio_serviceinvoices',
+                    'hook_aftercronjob_refresh_created_error',
+                    ['nfe_id' => $invoice->nfe_id, 'company_id' => $invoice->company_id],
+                    $apiResponse['error']
+                );
+                continue;
+            }
+
+            if (!is_object($apiResponse) || empty($apiResponse->id) || empty($apiResponse->status)) {
+                logModuleCall(
+                    'nfeio_serviceinvoices',
+                    'hook_aftercronjob_refresh_created_invalid_response',
+                    ['nfe_id' => $invoice->nfe_id, 'company_id' => $invoice->company_id],
+                    $apiResponse
+                );
+                continue;
+            }
+
+            $flowStatus = isset($apiResponse->flowStatus) ? $apiResponse->flowStatus : null;
+            $this->nf->updateLocalNfeStatus($apiResponse->id, $apiResponse->status, $flowStatus);
+        }
     }
 }

--- a/modules/addons/NFEioServiceInvoices/lib/Models/ModuleConfiguration/Repository.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Models/ModuleConfiguration/Repository.php
@@ -39,7 +39,8 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
         'descCustom',
         'footer',
         'iss_held',
-        'discount_items'
+        'discount_items',
+        'auto_refresh_created_status'
     );
 
     /**
@@ -68,7 +69,8 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
         'descCustom',
         'footer',
         'iss_held',
-        'discount_items'
+        'discount_items',
+        'auto_refresh_created_status'
     );
 
     /**
@@ -311,6 +313,15 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
             'required' => false,
             'disabled' => false,
             'description' => 'Informe o Código de Classificação Tributária para o IBS/CBS (classCode) padrão a ser utilizado na emissão das notas fiscais.',
+        ],
+        'auto_refresh_created_status' => [
+            'type' => 'checkbox',
+            'label' => 'Atualizar status de notas Criadas',
+            'name' => 'auto_refresh_created_status',
+            'id' => 'autoRefreshCreatedStatus_Field',
+            'required' => false,
+            'disabled' => false,
+            'description' => 'A cada execução do cron, consulta na API da NFE.io o status atualizado. Desativado por padrão.',
         ],
     );
 

--- a/modules/addons/NFEioServiceInvoices/lib/templates/admin/configuration.tpl
+++ b/modules/addons/NFEioServiceInvoices/lib/templates/admin/configuration.tpl
@@ -342,6 +342,31 @@
                         </div>
                     </div>
                     {* /gnfe_email_nfe_config *}
+                    {* auto_refresh_created_status *}
+                    <div class="form-group">
+                        <label class="control-label col-sm-4"
+                               for="{$moduleFields.auto_refresh_created_status.id}">{$moduleFields.auto_refresh_created_status.label}
+                            :</label>
+                        <div class="col-sm-8">
+                            <div class="checkbox">
+                                <label>
+                                    <input
+                                            type="{$moduleFields.auto_refresh_created_status.type}"
+                                            name="{$moduleFields.auto_refresh_created_status.name}"
+                                            id="{$moduleFields.auto_refresh_created_status.id}"
+                                            aria-describedby="{$moduleFields.auto_refresh_created_status.id}HelpBlock"
+                                            {if $moduleFields.auto_refresh_created_status.required}required{/if}
+                                            {if $moduleFields.auto_refresh_created_status.disabled}disabled{/if}
+                                            {if $auto_refresh_created_status == 'on'}checked{/if}
+                                    >
+                                    {$moduleFields.auto_refresh_created_status.label}
+                                </label>
+                                <span class="help-block"
+                                      id="{$moduleFields.auto_refresh_created_status.id}HelpBlock">{$moduleFields.auto_refresh_created_status.description}</span>
+                            </div>
+                        </div>
+                    </div>
+                    {* /auto_refresh_created_status *}
                     {* descCustom *}
                     <div class="form-group">
                         <label class="control-label col-sm-4"


### PR DESCRIPTION
## Resumo

Adiciona uma nova opção em **Configurações Globais** (desativada por padrão) que faz o `AfterCronJob` consultar na API da NFE.io o status atualizado das notas com status `Created` (Criada) e atualizar o banco local automaticamente — mesma rotina executada pelo botão **Atualizar** do painel administrativo.

## Motivação

Hoje, notas que ficam com status `Created` na API só têm o status local atualizado se o administrador clicar manualmente no botão **Atualizar** para cada uma. Em volumes maiores isso é inviável. Esta funcionalidade automatiza esse passo, mantendo o controle do operador via toggle.

## Comportamento

- **Toggle:** `Atualizar status de notas Criadas` (chave de storage `auto_refresh_created_status`). Desativada por padrão.
- **Quando habilitada:** a cada execução do cron do WHMCS, após o processamento normal das notas em fila (`Waiting`), o hook seleciona até **5 notas** com status `Created`, ordenadas por `updated_at` ascendente (mais antigas primeiro), e para cada uma chama `Nfe::fetchNf()` + `updateLocalNfeStatus()`.
- **Limite por ciclo:** 5 notas, evitando sobrecarga de API e timeout do cron. As demais entram no próximo ciclo.
- **Logs:** registrados em `nfeio_serviceinvoices` com as chaves `hook_aftercronjob_refresh_created`, `hook_aftercronjob_refresh_created_error` e `hook_aftercronjob_refresh_created_invalid_response`.

## Arquivos alterados

- `lib/Hooks/AfterCronJob.php` — novo método `refreshCreatedInvoicesStatus()` gated pela config
- `lib/Models/ModuleConfiguration/Repository.php` — declaração da nova chave nos arrays `fieldDeclaration`, `model` e `fields`
- `lib/templates/admin/configuration.tpl` — novo checkbox na tela de Configurações Globais
- `lib/Admin/Controller.php` — persistência do valor em `configurationSave()`

## Test plan

- [ ] Após atualizar o módulo, abrir **Configurações Globais** e confirmar que a opção "Atualizar status de notas Criadas" aparece desmarcada
- [ ] Salvar configurações com a opção desativada e verificar que o `AfterCronJob` **não** dispara o refresh (sem entradas `hook_aftercronjob_refresh_created` no log)
- [ ] Marcar a opção, salvar e aguardar próximo ciclo de cron — verificar log `hook_aftercronjob_refresh_created` com a quantidade
- [ ] Com mais de 5 notas em `Created`, confirmar que apenas 5 são processadas por ciclo
- [ ] Confirmar que o status local muda quando a API retorna status diferente de `Created`