### PR TITLE
feat(nfse): verificação em segundo plano do status das notas no AfterCronJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v3.4.0
+Esta versão adiciona a verificação em segundo plano do status das notas fiscais, cobrindo os casos em que a notificação de webhook não chega ao WHMCS.
+
+### Novos Recursos
+#### Verificação de status das notas no `AfterCronJob`
+Até aqui, o status local de uma nota só era atualizado por push (`callback.php`) ou manualmente, pelo botão "Atualizar status" do admin. Quando o webhook falha — segredo divergente, indisponibilidade do WHMCS no momento do POST, entrega abandonada após os retries — a nota permanece indefinidamente em um status intermediário no banco local, mesmo já tendo sido emitida na prefeitura. O cliente continua vendo a nota como pendente e o problema só é percebido quando alguém abre o admin.
+
+O hook `AfterCronJob`, que até então apenas emitia as notas na fila (`status = Waiting`), passa a executar também uma rotina de reconciliação: consulta na API da NFE.io as notas que já possuem `nfe_id` mas ainda não chegaram a um status final (`Issued`, `Cancelled`, `Error`) e atualiza `status` e `flow_status` locais quando houver divergência. A rotina é uma reserva do webhook, não uma substituição — as notas atualizadas por callback nunca entram na seleção.
+
+Duas configurações novas no menu **Configurações**:
+
+| Campo | Padrão | Função |
+| --- | --- | --- |
+| Verificar Status das Notas | desabilitado | Liga a rotina. Desligada, o hook mantém exatamente o comportamento anterior. |
+| Limite de Notas por Verificação | 50 | Teto de consultas por execução do cron. |
+
+Notas com menos de 15 minutos são ignoradas, dando ao webhook a chance de chegar primeiro, e a seleção é ordenada pela verificação mais antiga — assim o limite por execução escoa a fila sem que nenhuma nota fique para trás. Notas em `Waiting` não entram na seleção, por serem responsabilidade da rotina de emissão do mesmo hook.
+
+Cada execução registra um `logModuleCall` (`hook_aftercronjob_status_check`) com o total pendente, atualizadas, inalteradas e falhas.
+
 ## v3.3.1
 Esta versão corrige a emissão de NFS-e, que passou a falhar com `415 Unsupported Media Type` a partir de 24/07/2026.
 

--- a/modules/addons/NFEioServiceInvoices/lib/Admin/Controller.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Admin/Controller.php
@@ -521,6 +521,8 @@ class Controller
         //$footer = isset($post['footer']) ? $post['footer'] : ' ';
         $iss_held = isset($post['iss_held']) ? $post['iss_held'] : 0;
         $discount_items = isset($post['discount_items']) ? $post['discount_items'] : '';
+        $check_nf_status = isset($post['check_nf_status']) ? $post['check_nf_status'] : '';
+        $check_nf_status_limit = isset($post['check_nf_status_limit']) ? $post['check_nf_status_limit'] : '';
 
         // verifica cada campo e realiza a inserção das configurações no banco
         try {
@@ -550,6 +552,8 @@ class Controller
             $storage->set('iss_held', $iss_held);
             // discount_items
             $storage->set('discount_items', $discount_items);
+            $storage->set('check_nf_status', $check_nf_status);
+            $storage->set('check_nf_status_limit', $check_nf_status_limit);
 
             if ($rps_number) {
                 $storage->set('rps_number', $rps_number);

--- a/modules/addons/NFEioServiceInvoices/lib/Hooks/AfterCronJob.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Hooks/AfterCronJob.php
@@ -14,6 +14,10 @@ use WHMCS\Database\Capsule;
  */
 class AfterCronJob
 {
+    const STATUS_CHECK_MIN_AGE_MINUTES = 15;
+
+    const STATUS_CHECK_DEFAULT_LIMIT = 50;
+
     /**
      * @var \NFEioServiceInvoices\Configuration
      */
@@ -77,5 +81,29 @@ class AfterCronJob
             }
 
         }
+
+        $this->checkPendingNfStatus($storage);
+    }
+
+    private function checkPendingNfStatus($storage)
+    {
+        if ($storage->get('check_nf_status') !== 'on') {
+            return;
+        }
+
+        $limit = (int)$storage->get('check_nf_status_limit');
+
+        if ($limit <= 0) {
+            $limit = self::STATUS_CHECK_DEFAULT_LIMIT;
+        }
+
+        $result = $this->nf->syncPendingStatuses($limit, self::STATUS_CHECK_MIN_AGE_MINUTES);
+
+        logModuleCall(
+            'nfeio_serviceinvoices',
+            'hook_aftercronjob_status_check',
+            ['limite' => $limit, 'idade minima em minutos' => self::STATUS_CHECK_MIN_AGE_MINUTES],
+            $result
+        );
     }
 }

--- a/modules/addons/NFEioServiceInvoices/lib/Models/ModuleConfiguration/Repository.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Models/ModuleConfiguration/Repository.php
@@ -39,7 +39,9 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
         'descCustom',
         'footer',
         'iss_held',
-        'discount_items'
+        'discount_items',
+        'check_nf_status',
+        'check_nf_status_limit'
     );
 
     /**
@@ -68,7 +70,9 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
         'descCustom',
         'footer',
         'iss_held',
-        'discount_items'
+        'discount_items',
+        'check_nf_status',
+        'check_nf_status_limit'
     );
 
     /**
@@ -284,6 +288,24 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
             'required' => false,
             'disabled' => false,
             'description' => 'Deduzir descontos/abatimentos existentes na fatura do valor total da nota a ser emitida.',
+        ],
+        'check_nf_status' => [
+            'type' => 'checkbox',
+            'label' => 'Verificar Status das Notas',
+            'name' => 'check_nf_status',
+            'id' => 'checkNfStatus_Field',
+            'required' => false,
+            'disabled' => false,
+            'description' => 'Consultar na NFE.io, a cada execução do cron, o status das notas que ainda não chegaram a um status final. Recomendado como reserva caso alguma notificação de webhook não seja recebida.',
+        ],
+        'check_nf_status_limit' => [
+            'type' => 'text',
+            'label' => 'Limite de Notas por Verificação',
+            'name' => 'check_nf_status_limit',
+            'id' => 'checkNfStatusLimit_Field',
+            'required' => false,
+            'disabled' => false,
+            'description' => 'Quantidade máxima de notas consultadas por execução do cron. Se vazio, o padrão é 50.',
         ],
         'nbs_code' => [
             'type' => 'text',

--- a/modules/addons/NFEioServiceInvoices/lib/Models/ServiceInvoices/Repository.php
+++ b/modules/addons/NFEioServiceInvoices/lib/Models/ServiceInvoices/Repository.php
@@ -45,6 +45,12 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
         'tics',
         'company_id',
     );
+    public $terminalStatuses = array(
+        'Issued',
+        'Cancelled',
+        'Error',
+    );
+
     protected $_limit = 10;
 
     /**
@@ -360,6 +366,34 @@ class Repository extends \WHMCSExpert\mtLibs\models\Repository
                 $e->getTraceAsString()
             );
             return false;
+        }
+    }
+
+    public function getNotesPendingStatusCheck($minAgeMinutes, $limit)
+    {
+        $minAgeMinutes = (int)$minAgeMinutes;
+        $limit = (int)$limit;
+        $threshold = date('Y-m-d H:i:s', strtotime("-{$minAgeMinutes} minutes"));
+
+        try {
+            return Capsule::table($this->tableName)
+                ->whereNotNull('nfe_id')
+                ->where('nfe_id', '!=', '')
+                ->where('status', '!=', 'Waiting')
+                ->whereNotIn('status', $this->terminalStatuses)
+                ->whereRaw('COALESCE(updated_at, created_at) <= ?', [$threshold])
+                ->orderByRaw('COALESCE(updated_at, created_at) asc')
+                ->limit($limit)
+                ->get();
+        } catch (\Exception $e) {
+            logModuleCall(
+                'nfeio_serviceinvoices',
+                'getNotesPendingStatusCheck_error',
+                ['min_age_minutes' => $minAgeMinutes, 'limit' => $limit, 'threshold' => $threshold],
+                $e->getMessage(),
+                $e->getTraceAsString()
+            );
+            return new \Illuminate\Support\Collection([]);
         }
     }
 

--- a/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
+++ b/modules/addons/NFEioServiceInvoices/lib/NFEio/Nfe.php
@@ -794,6 +794,58 @@ class Nfe
         return $result;
     }
 
+    public function syncPendingStatuses($limit, $minAgeMinutes)
+    {
+        $companyRepo = new \NFEioServiceInvoices\Models\Company\Repository();
+        $defaultCompany = $companyRepo->getDefaultCompany();
+        $fallbackCompanyId = $defaultCompany ? $defaultCompany->company_id : null;
+        $pendingNotes = $this->serviceInvoicesRepo->getNotesPendingStatusCheck($minAgeMinutes, $limit);
+        $result = ['pending' => count($pendingNotes), 'updated' => 0, 'unchanged' => 0, 'failed' => 0];
+
+        foreach ($pendingNotes as $note) {
+            $companyId = !empty($note->company_id) ? $note->company_id : $fallbackCompanyId;
+
+            if (empty($companyId)) {
+                $result['failed']++;
+                logModuleCall(
+                    'nfeio_serviceinvoices',
+                    'sync_pending_statuses_error',
+                    ['nfe_id' => $note->nfe_id],
+                    'Empresa emissora não identificada para a nota.'
+                );
+                continue;
+            }
+
+            $remoteNote = $this->fetchNf($note->nfe_id, $companyId);
+
+            if (!is_object($remoteNote) || !isset($remoteNote->status)) {
+                $result['failed']++;
+                logModuleCall(
+                    'nfeio_serviceinvoices',
+                    'sync_pending_statuses_error',
+                    ['nfe_id' => $note->nfe_id, 'company_id' => $companyId],
+                    $remoteNote
+                );
+                continue;
+            }
+
+            $remoteFlowStatus = isset($remoteNote->flowStatus) ? $remoteNote->flowStatus : null;
+
+            if ($remoteNote->status === $note->status && (string)$remoteFlowStatus === (string)$note->flow_status) {
+                $result['unchanged']++;
+                continue;
+            }
+
+            if ($this->updateLocalNfeStatus($note->nfe_id, $remoteNote->status, $remoteFlowStatus)) {
+                $result['updated']++;
+            } else {
+                $result['failed']++;
+            }
+        }
+
+        return $result;
+    }
+
     /**
      * Atualiza o status de uma NF no banco local pelo externalId
      *

--- a/modules/addons/NFEioServiceInvoices/lib/templates/admin/configuration.tpl
+++ b/modules/addons/NFEioServiceInvoices/lib/templates/admin/configuration.tpl
@@ -215,6 +215,52 @@
                         </div>
                     </div>
                     {* cancel_invoice_cancel_nfe *}
+                    {* check_nf_status *}
+                    <div class="form-group">
+                        <label class="control-label col-sm-4"
+                               for="{$moduleFields.check_nf_status.id}">{$moduleFields.check_nf_status.label}
+                            :</label>
+                        <div class="col-sm-8">
+                            <div class="checkbox">
+                                <label>
+                                    <input
+                                            type="{$moduleFields.check_nf_status.type}"
+                                            name="{$moduleFields.check_nf_status.name}"
+                                            id="{$moduleFields.check_nf_status.id}"
+                                            aria-describedby="{$moduleFields.check_nf_status.id}HelpBlock"
+                                            {if $moduleFields.check_nf_status.required}required{/if}
+                                            {if $moduleFields.check_nf_status.disabled}disabled{/if}
+                                            {if $check_nf_status == 'on'}checked{/if}
+                                    >
+                                    {$moduleFields.check_nf_status.label}
+                                </label>
+                                <span class="help-block"
+                                      id="{$moduleFields.check_nf_status.id}HelpBlock">{$moduleFields.check_nf_status.description}</span>
+                            </div>
+
+                        </div>
+                    </div>
+                    {* /check_nf_status *}
+                    {* check_nf_status_limit *}
+                    <div class="form-group">
+                        <label class="control-label col-sm-4"
+                               for="{$moduleFields.check_nf_status_limit.id}">{$moduleFields.check_nf_status_limit.label}:</label>
+                        <div class="col-sm-8">
+                            <input
+                                    class="form-control"
+                                    type="{$moduleFields.check_nf_status_limit.type}"
+                                    name="{$moduleFields.check_nf_status_limit.name}"
+                                    id="{$moduleFields.check_nf_status_limit.id}"
+                                    aria-describedby="{$moduleFields.check_nf_status_limit.id}HelpBlock"
+                                    {if $moduleFields.check_nf_status_limit.required}required{/if}
+                                    {if $moduleFields.check_nf_status_limit.disabled}disabled{/if}
+                                    value="{$check_nf_status_limit}"
+                            >
+                            <span class="help-block"
+                                  id="{$moduleFields.check_nf_status_limit.id}HelpBlock">{$moduleFields.check_nf_status_limit.description}</span>
+                        </div>
+                    </div>
+                    {* /check_nf_status_limit *}
                     {* insc_municipal *}
                     <div class="form-group">
                         <label class="control-label col-sm-4"


### PR DESCRIPTION
## Problema

O status local de uma nota fiscal hoje só é atualizado por dois caminhos, ambos passivos:

| Caminho | Onde | Natureza |
| --- | --- | --- |
| Webhook da NFE.io | `callback.php` | **Push** — depende da NFE.io conseguir entregar |
| Botão "Atualizar status" no admin | `Admin\Controller::updateNfStatus` → `Nfe::fetchNf` | **Manual**, uma nota por vez |

`Nfe::fetchNf()` — a consulta de status na API — tem hoje um único chamador em todo o módulo: o botão manual do admin. Nenhuma rotina automatizada o utiliza.

O `AfterCronJob` existe, mas só **emite** as notas na fila (`status = Waiting`); depois do `emit()` a nota nunca mais é consultada. O `DailyCronJob` também não consulta status — apenas enfileira notas X dias após o pagamento.

Consequência: quando o webhook falha, a nota fica **indefinidamente** em um status intermediário no banco local, mesmo já tendo sido emitida com sucesso na prefeitura. O cliente continua vendo a nota como pendente no portal e o problema só é percebido quando alguém abre o admin e clica nota por nota.

Cenários em que isso acontece hoje:

- `webhook_secret` divergente entre módulo e NFE.io → `callback.php` responde `403` e **descarta** a notificação (linhas 39-43);
- WHMCS indisponível no momento do POST, e a NFE.io desiste após os retries;
- webhook não configurado ou removido na conta;
- payload rejeitado por qualquer das validações do callback (`400`/`404`), sem reenvio posterior.

Em todos eles não existe hoje nenhum mecanismo de recuperação automática.

## Solução

O `AfterCronJob` passa a executar, além da emissão já existente, uma rotina de reconciliação: consulta na API da NFE.io as notas que já possuem `nfe_id` mas ainda não chegaram a um status final (`Issued`, `Cancelled`, `Error`) e atualiza `status` e `flow_status` locais quando houver divergência.

É uma **reserva do webhook, não uma substituição**. Quando o callback funciona, ele continua sendo o caminho primário e as notas que ele atualiza saem naturalmente da seleção.

### Critérios de seleção

- `nfe_id` preenchido — notas ainda não emitidas não têm o que consultar;
- status fora de `Issued` / `Cancelled` / `Error` — status finais não são reconsultados;
- status diferente de `Waiting` — essas são responsabilidade da rotina de emissão do próprio hook, evitando que as duas rotinas disputem a mesma linha;
- `COALESCE(updated_at, created_at)` com pelo menos **15 minutos** — dá ao webhook a chance de chegar primeiro e evita consultar uma nota recém-emitida;
- ordenação pela verificação mais antiga, com teto por execução — assim o limite escoa a fila sem que nenhuma nota fique para trás.

### Configuração

Dois campos novos no menu **Configurações**:

| Campo | Chave | Padrão | Função |
| --- | --- | --- | --- |
| Verificar Status das Notas | `check_nf_status` | **desabilitado** | Liga a rotina |
| Limite de Notas por Verificação | `check_nf_status_limit` | `50` | Teto de consultas por execução do cron |

**Desabilitado por padrão.** Com a opção desligada, o `AfterCronJob` mantém exatamente o comportamento anterior — nenhuma chamada extra à API para quem não optar pelo recurso.

### Observabilidade

Cada execução registra um `logModuleCall` com a ação `hook_aftercronjob_status_check`, contendo o total pendente, atualizadas, inalteradas e falhas. Falhas por nota (empresa emissora não identificada, erro na API) são registradas individualmente em `sync_pending_statuses_error`.

## Alterações

| Arquivo | O quê |
| --- | --- |
| `lib/Hooks/AfterCronJob.php` | Chama a rotina ao final de `run()`, atrás da flag de configuração |
| `lib/NFEio/Nfe.php` | `syncPendingStatuses()` — percorre as notas pendentes, consulta via `fetchNf()` e aplica `updateLocalNfeStatus()` |
| `lib/Models/ServiceInvoices/Repository.php` | `getNotesPendingStatusCheck()` e a lista `terminalStatuses` |
| `lib/Models/ModuleConfiguration/Repository.php` | Declaração dos dois campos novos |
| `lib/Admin/Controller.php` | Persistência dos dois campos em `configurationSave()` |
| `lib/templates/admin/configuration.tpl` | Campos no formulário |
| `CHANGELOG.md` | Entrada `v3.4.0` |

Sem migração de banco — a rotina usa apenas colunas já existentes. Nenhum comportamento existente foi alterado: a emissão, o callback e o botão manual do admin seguem intactos.

## Compatibilidade

- PHP 7.4 preservado (sem typed properties, union types, match ou promoção de construtor);
- Multiempresa respeitado: usa o `company_id` da própria nota, com fallback para a empresa padrão (`Company\Repository::getDefaultCompany()`) nos registros anteriores à v3.0 que possam estar sem o campo;
- `php -l` limpo em todos os arquivos PHP alterados;
- versão em `Configuration.php` não foi alterada, seguindo o padrão do repositório de fazer o bump em commit próprio.

## Fora de escopo

Uma observação que apareceu durante a análise e que **não** foi tocada aqui, para manter o PR focado: uma nota em `Waiting` que já tenha `nfe_id` (emitida, mas cujo `updateServiceInvoice` não completou) continua sendo reprocessada pela rotina de emissão a cada execução do cron, com risco de emissão duplicada. Um guard de `nfe_id` vazio na query de emissão resolveria, mas altera comportamento existente — feliz em abrir um PR separado se fizer sentido para vocês.

## Como testar

1. Ativar **Verificar Status das Notas** em Configurações.
2. Provocar a falha do webhook (por exemplo, alterando o `webhook_secret` no módulo para um valor divergente do configurado na NFE.io).
3. Emitir uma nota e confirmar que ela permanece em status intermediário no banco local após a emissão concluir na NFE.io.
4. Aguardar 15 minutos e a próxima execução do cron do WHMCS.
5. Verificar que o status local foi reconciliado e que o log `hook_aftercronjob_status_check` registra a execução.
